### PR TITLE
Add auto re-approve checking for social transactions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "overrides": [],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,14 @@
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
-  "overrides": [],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@typescript-eslint/no-empty-function": "off"
+      }
+    }
+  ],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -196,3 +196,37 @@ const txInfo = submitPost({
 
 See the [transaction construction api documentation](https://docs.deso.org/deso-backend/construct-transactions) for reference.
 See an exhaustive list of the available transaction construction functions [here](https://github.com/deso-protocol/deso-js/tree/main/src/transactions)
+
+## Contributing
+
+Pull requests are welcome!
+
+### Setup
+
+- Clone this repo
+
+```sh
+  git clone ...
+  cd deso-js
+```
+
+### Useful workflows
+
+- Run the test suite
+
+```sh
+npm run test
+```
+
+- Link local changes into another project
+
+```sh
+# in the deso-js root directory run
+npm run link
+
+# navigate to your project's root
+cd $your_project_root_dir
+
+# create symlink in node_modules that points to your local copy of deso-protocol
+npm link deso-protocol
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,15 @@
         "@types/jest": "^29.5.1",
         "@types/jsonwebtoken": "^9.0.1",
         "@types/node": "^18.16.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.1",
+        "@typescript-eslint/parser": "^5.59.2",
         "bs58check": "^3.0.1",
         "elliptic": "^6.5.4",
         "eslint": "^8.39.0",
+        "eslint-config-standard-with-typescript": "^34.0.1",
+        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-n": "^15.7.0",
+        "eslint-plugin-promise": "^6.1.1",
         "husky": "^8.0.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
@@ -2065,6 +2071,18 @@
         "parse5": "^7.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
@@ -2084,6 +2102,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -2112,6 +2136,422 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz",
+      "integrity": "sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.1",
+        "@typescript-eslint/type-utils": "5.59.1",
+        "@typescript-eslint/utils": "5.59.1",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
+      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
+      "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/visitor-keys": "5.59.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz",
+      "integrity": "sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/utils": "5.59.1",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
+      "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
+      "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/visitor-keys": "5.59.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
+      "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.1",
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.1",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
+      "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -2281,6 +2721,83 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -2313,6 +2830,18 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.5.0",
@@ -2531,6 +3060,61 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2871,6 +3455,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-properties": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2905,6 +3505,18 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -3008,6 +3620,94 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
+        "es-to-primitive": "^1.2.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.2.0",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -3161,6 +3861,259 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard-with-typescript": {
+      "version": "34.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-34.0.1.tgz",
+      "integrity": "sha512-J7WvZeLtd0Vr9F+v4dZbqJCLD16cbIy4U+alJMq4MiXdpipdBM3U5NkXaGUjePc4sb1ZE01U9g6VuTBpHHz1fg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^5.43.0",
+        "eslint-config-standard": "17.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.43.0",
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.27.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "array.prototype.flatmap": "^1.3.1",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-module-utils": "^2.7.4",
+        "has": "^1.0.3",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.6",
+        "resolve": "^1.22.1",
+        "semver": "^6.3.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
@@ -3175,6 +4128,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -3362,6 +4342,34 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3451,6 +4459,15 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3491,6 +4508,33 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3507,6 +4551,20 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -3528,6 +4586,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -3577,6 +4651,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3601,6 +4722,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3608,6 +4738,57 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hash.js": {
@@ -3787,11 +4968,79 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/internal-slot": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.12.0",
@@ -3800,6 +5049,21 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3847,6 +5111,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3854,6 +5130,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-path-inside": {
@@ -3871,6 +5162,34 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -3881,6 +5200,67 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isexe": {
@@ -5221,6 +6601,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -5289,6 +6678,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5299,6 +6697,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "node_modules/node-int64": {
@@ -5360,6 +6764,50 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5533,6 +6981,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -5768,6 +7225,35 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5959,6 +7445,20 @@
         }
       ]
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6010,6 +7510,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6171,6 +7685,51 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -6447,10 +8006,64 @@
         }
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -6486,6 +8099,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -6497,6 +8124,21 @@
       },
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/universalify": {
@@ -6660,6 +8302,42 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
+    "package": "npm run build && cp {package.json,README.md,LICENSE} ./lib && cd ./lib && npm pkg delete scripts && cd -",
+    "link": "npm run package && cd ./lib && npm i && npm link",
     "prepare": "husky install",
     "precommit": "lint-staged && npm run test"
   },
@@ -28,7 +30,7 @@
   },
   "homepage": "https://github.com/deso-protocol/deso-js#readme",
   "lint-staged": {
-    "{libs,apps}/**/*.{js,jsx,ts,tsx}": [
+    "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "prettier --write"
     ],
@@ -39,18 +41,24 @@
   "dependencies": {
     "@noble/hashes": "^1.3.0",
     "@noble/secp256k1": "^1.7.1",
-    "@types/elliptic": "^6.4.14",
     "bs58": "^5.0.0",
     "ethers": "^5.6.6",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
+    "@types/elliptic": "^6.4.14",
     "@types/jest": "^29.5.1",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/node": "^18.16.1",
+    "@typescript-eslint/eslint-plugin": "^5.59.1",
+    "@typescript-eslint/parser": "^5.59.2",
     "bs58check": "^3.0.1",
     "elliptic": "^6.5.4",
     "eslint": "^8.39.0",
+    "eslint-config-standard-with-typescript": "^34.0.1",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-n": "^15.7.0",
+    "eslint-plugin-promise": "^6.1.1",
     "husky": "^8.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",

--- a/scripts/github-workflows/publish_new_version.sh
+++ b/scripts/github-workflows/publish_new_version.sh
@@ -19,8 +19,7 @@ echo "Pre-release tag: $NPM_PRERELEASE_TAG"
 
 npm ci --ignore-scripts
 npm version --no-git-tag-version $NEW_VERSION
-npm run build
-cp {package.json,README.md,LICENSE} ./lib
+npm run package
 cd ./lib
 
 # If the version is a pre-release (beta), publish with the --tag flag.

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../.eslintrc.json",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "project": "./tsconfig.spec.json"
+  }
+}

--- a/src/backend-types/deso-types-custom.ts
+++ b/src/backend-types/deso-types-custom.ts
@@ -315,35 +315,6 @@ export interface DAOCoinLimitOrderWithExchangeRateAndQuantityRequest {
   MinFeeRateNanosPerKB?: number;
   TransactionFees: TransactionFee[] | null;
 }
-export enum TxnString {
-  TxnStringUnset = 'UNSET',
-  TxnStringBlockReward = 'BLOCK_REWARD',
-  TxnStringBasicTransfer = 'BASIC_TRANSFER',
-  TxnStringBitcoinExchange = 'BITCOIN_EXCHANGE',
-  TxnStringPrivateMessage = 'PRIVATE_MESSAGE',
-  TxnStringSubmitPost = 'SUBMIT_POST',
-  TxnStringUpdateProfile = 'UPDATE_PROFILE',
-  TxnStringUpdateBitcoinUSDExchangeRate = 'UPDATE_BITCOIN_USD_EXCHANGE_RATE',
-  TxnStringFollow = 'FOLLOW',
-  TxnStringLike = 'LIKE',
-  TxnStringCreatorCoin = 'CREATOR_COIN',
-  TxnStringSwapIdentity = 'SWAP_IDENTITY',
-  TxnStringUpdateGlobalParams = 'UPDATE_GLOBAL_PARAMS',
-  TxnStringCreatorCoinTransfer = 'CREATOR_COIN_TRANSFER',
-  TxnStringCreateNFT = 'CREATE_NFT',
-  TxnStringUpdateNFT = 'UPDATE_NFT',
-  TxnStringAcceptNFTBid = 'ACCEPT_NFT_BID',
-  TxnStringNFTBid = 'NFT_BID',
-  TxnStringNFTTransfer = 'NFT_TRANSFER',
-  TxnStringAcceptNFTTransfer = 'ACCEPT_NFT_TRANSFER',
-  TxnStringBurnNFT = 'BURN_NFT',
-  TxnStringAuthorizeDerivedKey = 'AUTHORIZE_DERIVED_KEY',
-  TxnStringMessagingGroup = 'MESSAGING_GROUP',
-  TxnStringDAOCoin = 'DAO_COIN',
-  TxnStringDAOCoinTransfer = 'DAO_COIN_TRANSFER',
-  TxnStringDAOCoinLimitOrder = 'DAO_COIN_LIMIT_ORDER',
-  TxnStringUndefined = 'TXN_UNDEFINED',
-}
 
 export interface MetaMaskInitResponse {
   derivedKeyPair: ec.KeyPair;

--- a/src/backend-types/deso-types.ts
+++ b/src/backend-types/deso-types.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
+import { type TransactionType } from '../backend-types/deso-types-custom';
+
 // this file was automatically generated, DO NOT EDIT
 export type DB = any;
 
@@ -70,7 +72,7 @@ export interface AncestralRecordValue {
 
 // struct2ts:types/generated/types.AncestralCache
 export interface AncestralCache {
-  AncestralRecordsMap: { [key: string]: AncestralRecordValue };
+  AncestralRecordsMap: Record<string, AncestralRecordValue>;
 }
 
 // struct2ts:types/generated/types.SnapshotOperation
@@ -201,7 +203,7 @@ export interface MessageEntry {
   SenderMessagingGroupKeyName: number[];
   RecipientMessagingPublicKey: number[];
   RecipientMessagingGroupKeyName: number[];
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.MessagingGroupMember
@@ -217,7 +219,7 @@ export interface MessagingGroupEntry {
   MessagingPublicKey: number[];
   MessagingGroupKeyName: number[];
   MessagingGroupMembers: MessagingGroupMember[] | null;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.PGMessage
@@ -227,7 +229,7 @@ export interface PGMessage {
   RecipientPublicKey: number[] | null;
   EncryptedText: number[] | null;
   TimestampNanos: number;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.FollowEntry
@@ -249,7 +251,7 @@ export interface NFTEntry {
   IsPending: boolean;
   IsBuyNow: boolean;
   BuyNowPriceNanos: number;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.NFTBidEntry
@@ -308,9 +310,9 @@ export interface PostEntry {
   HasUnlockable: boolean;
   NFTRoyaltyToCreatorBasisPoints: number;
   NFTRoyaltyToCoinBasisPoints: number;
-  AdditionalNFTRoyaltiesToCreatorsBasisPoints: { [key: string]: number };
-  AdditionalNFTRoyaltiesToCoinsBasisPoints: { [key: string]: number };
-  PostExtraData: { [key: string]: number };
+  AdditionalNFTRoyaltiesToCreatorsBasisPoints: Record<string, number>;
+  AdditionalNFTRoyaltiesToCoinsBasisPoints: Record<string, number>;
+  PostExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.PKIDEntry
@@ -339,7 +341,7 @@ export interface ProfileEntry {
   IsHidden: boolean;
   CreatorCoinEntry: CoinEntry;
   DAOCoinEntry: CoinEntry;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.BalanceEntry
@@ -353,11 +355,11 @@ export interface BalanceEntry {
 // struct2ts:types/generated/types.TransactionSpendingLimit
 export interface TransactionSpendingLimit {
   GlobalDESOLimit: number;
-  TransactionCountLimitMap: { [key: number]: number };
-  CreatorCoinOperationLimitMap: { [key: string]: number };
-  DAOCoinOperationLimitMap: { [key: string]: number };
-  NFTOperationLimitMap: { [key: string]: number };
-  DAOCoinLimitOrderLimitMap: { [key: string]: number };
+  TransactionCountLimitMap: Record<number, number>;
+  CreatorCoinOperationLimitMap: Record<string, number>;
+  DAOCoinOperationLimitMap: Record<string, number>;
+  NFTOperationLimitMap: Record<string, number>;
+  DAOCoinLimitOrderLimitMap: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.DerivedKeyEntry
@@ -366,7 +368,7 @@ export interface DerivedKeyEntry {
   DerivedPublicKey: number[];
   ExpirationBlock: number;
   OperationType: number;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
   TransactionSpendingLimitTracker: TransactionSpendingLimit | null;
   Memo: number[] | null;
 }
@@ -540,7 +542,7 @@ export interface MsgDeSoTxn {
   TxOutputs: DeSoOutput[] | null;
   TxnMeta: any;
   PublicKey: string | null;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
   Signature: Signature | null;
   TxnTypeJSON: number;
 }
@@ -640,7 +642,7 @@ export interface DeSoParams {
   MaxStakeMultipleBasisPoints: number;
   MaxCreatorBasisPoints: number;
   MaxNFTRoyaltyBasisPoints: number;
-  ParamUpdaterPublicKeys: { [key: string]: boolean };
+  ParamUpdaterPublicKeys: Record<string, boolean>;
   SeedTxns: string[] | null;
   SeedBalances: DeSoOutput[] | null;
   CreatorCoinTradeFeeBasisPoints: number;
@@ -655,42 +657,35 @@ export interface DeSoParams {
 // struct2ts:types/generated/types.UtxoView
 export interface UtxoView {
   NumUtxoEntries: number;
-  UtxoKeyToUtxoEntry: { [key: string]: UtxoEntry };
-  PublicKeyToDeSoBalanceNanos: { [key: string]: number };
+  UtxoKeyToUtxoEntry: Record<string, UtxoEntry>;
+  PublicKeyToDeSoBalanceNanos: Record<string, number>;
   NanosPurchased: number;
   USDCentsPerBitcoin: number;
   GlobalParamsEntry: GlobalParamsEntry | null;
-  BitcoinBurnTxIDs: { [key: BlockHash]: boolean };
-  ForbiddenPubKeyToForbiddenPubKeyEntry: {
-    [key: PkMapKey]: ForbiddenPubKeyEntry;
-  };
-  MessageKeyToMessageEntry: { [key: string]: MessageEntry };
-  MessagingGroupKeyToMessagingGroupEntry: {
-    [key: string]: MessagingGroupEntry;
-  };
-  MessageMap: { [key: BlockHash]: PGMessage };
-  FollowKeyToFollowEntry: { [key: string]: FollowEntry };
-  NFTKeyToNFTEntry: { [key: string]: NFTEntry };
-  NFTBidKeyToNFTBidEntry: { [key: string]: NFTBidEntry };
-  NFTKeyToAcceptedNFTBidHistory: { [key: string]: NFTBidEntry };
-  DiamondKeyToDiamondEntry: { [key: string]: DiamondEntry };
-  LikeKeyToLikeEntry: { [key: string]: LikeEntry };
-  RepostKeyToRepostEntry: { [key: string]: RepostEntry };
-  PostHashToPostEntry: { [key: BlockHash]: PostEntry };
-  PublicKeyToPKIDEntry: { [key: PkMapKey]: PKIDEntry };
-  PKIDToPublicKey: { [key: string]: PKIDEntry };
-  ProfilePKIDToProfileEntry: { [key: string]: ProfileEntry };
-  ProfileUsernameToProfileEntry: { [key: UsernameMapKey]: ProfileEntry };
-  HODLerPKIDCreatorPKIDToBalanceEntry: {
-    [key: string]: BalanceEntry;
-  };
-  HODLerPKIDCreatorPKIDToDAOCoinBalanceEntry: {
-    [key: string]: BalanceEntry;
-  };
-  DerivedKeyToDerivedEntry: { [key: string]: DerivedKeyEntry };
-  DAOCoinLimitOrderMapKeyToDAOCoinLimitOrderEntry: {
-    [key: string]: DAOCoinLimitOrderEntry;
-  };
+  BitcoinBurnTxIDs: Record<BlockHash, boolean>;
+  ForbiddenPubKeyToForbiddenPubKeyEntry: Record<PkMapKey, ForbiddenPubKeyEntry>;
+  MessageKeyToMessageEntry: Record<string, MessageEntry>;
+  MessagingGroupKeyToMessagingGroupEntry: Record<string, MessagingGroupEntry>;
+  MessageMap: Record<BlockHash, PGMessage>;
+  FollowKeyToFollowEntry: Record<string, FollowEntry>;
+  NFTKeyToNFTEntry: Record<string, NFTEntry>;
+  NFTBidKeyToNFTBidEntry: Record<string, NFTBidEntry>;
+  NFTKeyToAcceptedNFTBidHistory: Record<string, NFTBidEntry>;
+  DiamondKeyToDiamondEntry: Record<string, DiamondEntry>;
+  LikeKeyToLikeEntry: Record<string, LikeEntry>;
+  RepostKeyToRepostEntry: Record<string, RepostEntry>;
+  PostHashToPostEntry: Record<BlockHash, PostEntry>;
+  PublicKeyToPKIDEntry: Record<PkMapKey, PKIDEntry>;
+  PKIDToPublicKey: Record<string, PKIDEntry>;
+  ProfilePKIDToProfileEntry: Record<string, ProfileEntry>;
+  ProfileUsernameToProfileEntry: Record<UsernameMapKey, ProfileEntry>;
+  HODLerPKIDCreatorPKIDToBalanceEntry: Record<string, BalanceEntry>;
+  HODLerPKIDCreatorPKIDToDAOCoinBalanceEntry: Record<string, BalanceEntry>;
+  DerivedKeyToDerivedEntry: Record<string, DerivedKeyEntry>;
+  DAOCoinLimitOrderMapKeyToDAOCoinLimitOrderEntry: Record<
+    string,
+    DAOCoinLimitOrderEntry
+  >;
   TipHash: number[];
   Handle: DB | null;
   Postgres: Postgres | null;
@@ -756,7 +751,7 @@ export interface UtxoOperation {
   PrevRepostEntry: RepostEntry | null;
   PrevRepostCount: number;
   PrevCoinEntry: CoinEntry | null;
-  PrevCoinRoyaltyCoinEntries: { [key: string]: CoinEntry };
+  PrevCoinRoyaltyCoinEntries: Record<string, CoinEntry>;
   PrevTransactorBalanceEntry: BalanceEntry | null;
   PrevCreatorBalanceEntry: BalanceEntry | null;
   FounderRewardUtxoKey: UtxoKey | null;
@@ -781,7 +776,7 @@ export interface UtxoOperation {
   NFTBidAdditionalCoinRoyalties: PublicKeyRoyaltyPair[] | null;
   NFTBidAdditionalDESORoyalties: PublicKeyRoyaltyPair[] | null;
   PrevTransactorDAOCoinLimitOrderEntry: DAOCoinLimitOrderEntry | null;
-  PrevBalanceEntries: { [key: string]: string };
+  PrevBalanceEntries: Record<string, string>;
   PrevMatchingOrders: DAOCoinLimitOrderEntry[] | null;
   FilledDAOCoinLimitOrders: FilledDAOCoinLimitOrder[] | null;
 }
@@ -963,7 +958,7 @@ export interface DBPrefixes {
 // struct2ts:types/generated/types.DBStatePrefixes
 export interface DBStatePrefixes {
   Prefixes: DBPrefixes | null;
-  StatePrefixesMap: { [key: number]: boolean };
+  StatePrefixesMap: Record<number, boolean>;
   StatePrefixesList: number[] | null;
   TxIndexPrefixes: number[] | null;
 }
@@ -1092,8 +1087,8 @@ export interface NFTRoyaltiesMetadata {
   CreatorCoinRoyaltyNanos: number;
   CreatorRoyaltyNanos: number;
   CreatorPublicKeyBase58Check: string;
-  AdditionalCoinRoyaltiesMap: { [key: string]: number };
-  AdditionalDESORoyaltiesMap: { [key: string]: number };
+  AdditionalCoinRoyaltiesMap: Record<string, number>;
+  AdditionalDESORoyaltiesMap: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.NFTBidTxindexMetadata
@@ -1135,8 +1130,8 @@ export interface BurnNFTTxindexMetadata {
 // struct2ts:types/generated/types.CreateNFTTxindexMetadata
 export interface CreateNFTTxindexMetadata {
   NFTPostHashHex: string;
-  AdditionalCoinRoyaltiesMap: { [key: string]: number };
-  AdditionalDESORoyaltiesMap: { [key: string]: number };
+  AdditionalCoinRoyaltiesMap: Record<string, number>;
+  AdditionalDESORoyaltiesMap: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.UpdateNFTTxindexMetadata
@@ -1831,7 +1826,7 @@ export interface PGTransaction {
   BlockHash: number[];
   Type: number;
   PublicKey: number[] | null;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
   R: number[];
   S: number[];
   Outputs: PGTransactionOutput[] | null;
@@ -1889,7 +1884,7 @@ export interface PGProfile {
   DAOCoinCoinsInCirculationNanos: string;
   DAOCoinMintingDisabled: boolean;
   DAOCoinTransferRestrictionStatus: number;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.PGPost
@@ -1915,9 +1910,9 @@ export interface PGPost {
   Unlockable: boolean;
   CreatorRoyaltyBasisPoints: number;
   CoinRoyaltyBasisPoints: number;
-  AdditionalNFTRoyaltiesToCoinsBasisPoints: { [key: string]: number };
-  AdditionalNFTRoyaltiesToCreatorsBasisPoints: { [key: string]: number };
-  ExtraData: { [key: string]: number };
+  AdditionalNFTRoyaltiesToCoinsBasisPoints: Record<string, number>;
+  AdditionalNFTRoyaltiesToCreatorsBasisPoints: Record<string, number>;
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.PGLike
@@ -1946,7 +1941,7 @@ export interface PGMessagingGroup {
   MessagingPublicKey: number[];
   MessagingGroupKeyName: number[];
   MessagingGroupMembers: number[] | null;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.PGCreatorCoinBalance
@@ -2019,7 +2014,7 @@ export interface PGNFT {
   IsPending: boolean;
   IsBuyNow: boolean;
   BuyNowPriceNanos: number;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.PGNFTBid
@@ -2038,7 +2033,7 @@ export interface PGDerivedKey {
   DerivedPublicKey: number[];
   ExpirationBlock: number;
   OperationType: number;
-  ExtraData: { [key: string]: number };
+  ExtraData: Record<string, number>;
   TransactionSpendingLimitTracker: TransactionSpendingLimit | null;
   Memo: number[] | null;
 }
@@ -2204,7 +2199,7 @@ export interface PostEntryResponse {
   InGlobalFeed: boolean | null;
   InHotFeed: boolean | null;
   IsPinned: boolean | null;
-  PostExtraData: { [key: string]: string };
+  PostExtraData: Record<string, string>;
   CommentCount: number;
   RepostCount: number;
   QuoteRepostCount: number;
@@ -2216,8 +2211,8 @@ export interface PostEntryResponse {
   HasUnlockable: boolean;
   NFTRoyaltyToCreatorBasisPoints: number;
   NFTRoyaltyToCoinBasisPoints: number;
-  AdditionalDESORoyaltiesMap: { [key: string]: number };
-  AdditionalCoinRoyaltiesMap: { [key: string]: number };
+  AdditionalDESORoyaltiesMap: Record<string, number>;
+  AdditionalCoinRoyaltiesMap: Record<string, number>;
   DiamondsFromSender: number;
   HotnessScore: number;
   PostMultiplier: number;
@@ -2275,7 +2270,7 @@ export interface ProfileEntryResponse {
   UsersThatHODL: BalanceEntryResponse[] | null;
   IsFeaturedTutorialWellKnownCreator: boolean;
   IsFeaturedTutorialUpAndComingCreator: boolean;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.TransactionFee
@@ -2293,7 +2288,7 @@ export interface AdminSetTransactionFeeForTransactionTypeRequest {
 
 // struct2ts:types/generated/types.AdminSetTransactionFeeForTransactionTypeResponse
 export interface AdminSetTransactionFeeForTransactionTypeResponse {
-  TransactionFeeMap: { [key: string]: TransactionFee };
+  TransactionFeeMap: Record<string, TransactionFee>;
 }
 
 // struct2ts:types/generated/types.AdminSetAllTransactionFeesRequest
@@ -2303,12 +2298,12 @@ export interface AdminSetAllTransactionFeesRequest {
 
 // struct2ts:types/generated/types.AdminSetAllTransactionFeesResponse
 export interface AdminSetAllTransactionFeesResponse {
-  TransactionFeeMap: { [key: string]: TransactionFee };
+  TransactionFeeMap: Record<string, TransactionFee>;
 }
 
 // struct2ts:types/generated/types.AdminGetTransactionFeeMapResponse
 export interface AdminGetTransactionFeeMapResponse {
-  TransactionFeeMap: { [key: string]: TransactionFee };
+  TransactionFeeMap: Record<string, TransactionFee>;
 }
 
 // struct2ts:types/generated/types.AdminAddExemptPublicKey
@@ -2319,7 +2314,7 @@ export interface AdminAddExemptPublicKey {
 
 // struct2ts:types/generated/types.AdminGetExemptPublicKeysResponse
 export interface AdminGetExemptPublicKeysResponse {
-  ExemptPublicKeyMap: { [key: string]: ProfileEntryResponse };
+  ExemptPublicKeyMap: Record<string, ProfileEntryResponse>;
 }
 
 // struct2ts:types/generated/types.AdminResetJumioRequest
@@ -2404,7 +2399,7 @@ export interface CountrySignUpBonusResponse {
 
 // struct2ts:types/generated/types.GetAllCountryLevelSignUpBonusResponse
 export interface GetAllCountryLevelSignUpBonusResponse {
-  SignUpBonusMetadata: { [key: string]: CountrySignUpBonusResponse };
+  SignUpBonusMetadata: Record<string, CountrySignUpBonusResponse>;
   DefaultSignUpBonusMetadata: CountryLevelSignUpBonus;
 }
 
@@ -2483,7 +2478,7 @@ export interface NodeControlResponse {
 
 // struct2ts:types/generated/types.AdminGetMempoolStatsResponse
 export interface AdminGetMempoolStatsResponse {
-  TransactionSummaryStats: { [key: string]: SummaryStats };
+  TransactionSummaryStats: Record<string, SummaryStats>;
 }
 
 // struct2ts:types/generated/types.AdminCreateReferralHashRequest
@@ -2691,11 +2686,11 @@ export interface UserMetadata {
   EmailVerified: boolean;
   PhoneNumber: string;
   PhoneNumberCountryCode: string;
-  MessageReadStateByContact: { [key: string]: number };
+  MessageReadStateByContact: Record<string, number>;
   NotificationLastSeenIndex: number;
   SatoshisBurnedSoFar: number;
   HasBurnedEnoughSatoshisToCreateProfile: boolean;
-  BlockedPublicKeys: { [key: string]: string };
+  BlockedPublicKeys: Record<string, string>;
   WhitelistPosts: boolean;
   JumioInternalReference: string;
   JumioFinishedTime: number;
@@ -2720,8 +2715,8 @@ export interface UserMetadata {
 
 // struct2ts:types/generated/types.AdminGetAllUserGlobalMetadataResponse
 export interface AdminGetAllUserGlobalMetadataResponse {
-  PubKeyToUserGlobalMetadata: { [key: string]: UserMetadata };
-  PubKeyToUsername: { [key: string]: string };
+  PubKeyToUserGlobalMetadata: Record<string, UserMetadata>;
+  PubKeyToUsername: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.AdminGetUserGlobalMetadataRequest
@@ -2737,7 +2732,7 @@ export interface AdminGetUserGlobalMetadataResponse {
 
 // struct2ts:types/generated/types.VerifiedUsernameToPKID
 export interface VerifiedUsernameToPKID {
-  VerifiedUsernameToPKID: { [key: string]: PKID };
+  VerifiedUsernameToPKID: Record<string, PKID>;
 }
 
 // struct2ts:types/generated/types.VerificationUsernameAuditLog
@@ -2879,7 +2874,7 @@ export interface GetAppStateResponse {
   HasTwilioAPIKey: boolean;
   CreateProfileFeeNanos: number;
   CompProfileCreation: boolean;
-  DiamondLevelMap: { [key: number]: number };
+  DiamondLevelMap: Record<number, number>;
   HasWyreIntegration: boolean;
   HasJumioIntegration: boolean;
   BuyWithETH: boolean;
@@ -2889,9 +2884,9 @@ export interface GetAppStateResponse {
   JumioKickbackUSDCents: number;
   CountrySignUpBonus: CountryLevelSignUpBonus;
   DefaultFeeRateNanosPerKB: number;
-  TransactionFeeMap: { [key: string]: TransactionFee };
+  TransactionFeeMap: Record<string, TransactionFee>;
   BuyETHAddress: string;
-  Nodes: { [key: number]: DeSoNode };
+  Nodes: Record<number, DeSoNode>;
   USDCentsPerBitCloutExchangeRate: number;
   JumioBitCloutNanos: number;
 }
@@ -3025,7 +3020,7 @@ export interface TransactionResponse {
   TransactionType: string;
   BlockHashHex: string;
   TransactionMetadata: TransactionMetadata;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.APIBaseResponse
@@ -3320,7 +3315,7 @@ export interface AdminUpdateHotFeedAlgorithmRequest {
   InteractionCapTag: number;
   TimeDecayBlocks: number;
   TimeDecayBlocksTag: number;
-  TxnTypeMultiplierMap: { [key: number]: number };
+  TxnTypeMultiplierMap: Record<number, number>;
 }
 
 // struct2ts:types/generated/types.AdminGetHotFeedAlgorithmResponse
@@ -3329,7 +3324,7 @@ export interface AdminGetHotFeedAlgorithmResponse {
   InteractionCapTag: number;
   TimeDecayBlocks: number;
   TimeDecayBlocksTag: number;
-  TxnTypeMultiplierMap: { [key: number]: number };
+  TxnTypeMultiplierMap: Record<number, number>;
 }
 
 // struct2ts:types/generated/types.AdminUpdateHotFeedPostMultiplierRequest
@@ -3373,7 +3368,7 @@ export interface GetFullTikTokURLResponse {
 
 // struct2ts:types/generated/types.CFVideoDetailsResponse
 export interface CFVideoDetailsResponse {
-  result: { [key: string]: any };
+  result: Record<string, any>;
   success: boolean;
   errors: any;
   messages: any;
@@ -3385,7 +3380,7 @@ export interface GetVideoDimensionsResponse {
 }
 
 export interface EnableVideoDownloadResponse {
-  Default: { [k: string]: any };
+  Default: Record<string, any>;
 }
 
 // struct2ts:types/generated/types.GetMessagesStatelessRequest
@@ -3413,7 +3408,7 @@ export interface MessageEntryResponse {
   SenderMessagingGroupKeyName: string;
   RecipientMessagingPublicKey: string;
   RecipientMessagingGroupKeyName: string;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.MessageContactResponse
@@ -3438,14 +3433,14 @@ export interface MessagingGroupEntryResponse {
   MessagingGroupKeyName: string;
   MessagingGroupMembers: MessagingGroupMemberResponse[] | null;
   EncryptedKey: string;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.GetMessagesResponse
 export interface GetMessagesResponse {
-  PublicKeyToProfileEntry: { [key: string]: ProfileEntryResponse };
+  PublicKeyToProfileEntry: Record<string, ProfileEntryResponse>;
   OrderedContactsWithMessages: MessageContactResponse[] | null;
-  UnreadStateByContact: { [key: string]: boolean };
+  UnreadStateByContact: Record<string, boolean>;
   NumberOfUnreadThreads: number;
   MessagingGroups: MessagingGroupEntryResponse[] | null;
 }
@@ -3460,7 +3455,7 @@ export interface SendMessageStatelessRequest {
   TransactionFees: TransactionFee[] | null;
   SenderMessagingGroupKeyName: string;
   RecipientMessagingGroupKeyName: string;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.SendMessageStatelessResponse
@@ -3492,7 +3487,7 @@ export interface RegisterMessagingGroupKeyRequest {
   MessagingPublicKeyBase58Check: string;
   MessagingGroupKeyName: string;
   MessagingKeySignatureHex: string;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[] | null;
 }
@@ -3581,7 +3576,7 @@ export interface NFTEntryResponse {
   LowestBidAmountNanos: number;
   LastOwnerPublicKeyBase58Check: string | null;
   EncryptedUnlockableText: string | null;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.NFTCollectionResponse
@@ -3623,9 +3618,9 @@ export interface CreateNFTRequest {
   MinBidAmountNanos: number;
   IsBuyNow: boolean;
   BuyNowPriceNanos: number;
-  AdditionalDESORoyaltiesMap: { [key: string]: number };
-  AdditionalCoinRoyaltiesMap: { [key: string]: number };
-  ExtraData: { [key: string]: string };
+  AdditionalDESORoyaltiesMap: Record<string, number>;
+  AdditionalCoinRoyaltiesMap: Record<string, number>;
+  ExtraData: Record<string, string>;
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[] | null;
 }
@@ -3743,7 +3738,7 @@ export interface NFTEntryAndPostEntryResponse {
 
 // struct2ts:types/generated/types.GetNFTsForUserResponse
 export interface GetNFTsForUserResponse {
-  NFTsMap: { [key: string]: NFTEntryAndPostEntryResponse };
+  NFTsMap: Record<string, NFTEntryAndPostEntryResponse>;
 }
 
 // struct2ts:types/generated/types.GetNFTBidsForUserRequest
@@ -3755,10 +3750,11 @@ export interface GetNFTBidsForUserRequest {
 // struct2ts:types/generated/types.GetNFTBidsForUserResponse
 export interface GetNFTBidsForUserResponse {
   NFTBidEntries: NFTBidEntryResponse[] | null;
-  PublicKeyBase58CheckToProfileEntryResponse: {
-    [key: string]: ProfileEntryResponse;
-  };
-  PostHashHexToPostEntryResponse: { [key: string]: PostEntryResponse };
+  PublicKeyBase58CheckToProfileEntryResponse: Record<
+    string,
+    ProfileEntryResponse
+  >;
+  PostHashHexToPostEntryResponse: Record<string, PostEntryResponse>;
 }
 
 // struct2ts:types/generated/types.GetNFTBidsForNFTPostRequest
@@ -3783,7 +3779,7 @@ export interface GetNFTCollectionSummaryRequest {
 // struct2ts:types/generated/types.GetNFTCollectionSummaryResponse
 export interface GetNFTCollectionSummaryResponse {
   NFTCollectionResponse: NFTCollectionResponse | null;
-  SerialNumberToNFTEntryResponse: { [key: number]: NFTEntryResponse };
+  SerialNumberToNFTEntryResponse: Record<number, NFTEntryResponse>;
 }
 
 // struct2ts:types/generated/types.GetNFTEntriesForPostHashRequest
@@ -3886,7 +3882,7 @@ export interface GetNFTsCreatedByPublicKeyResponse {
 
 // struct2ts:types/generated/types.GetAcceptedBidHistoryResponse
 export interface GetAcceptedBidHistoryResponse {
-  AcceptedBidHistoryMap: { [key: number]: NFTBidEntryResponse };
+  AcceptedBidHistoryMap: Record<number, NFTBidEntryResponse>;
 }
 
 // struct2ts:types/generated/types.GetPostsStatelessRequest
@@ -4139,7 +4135,7 @@ export interface AdminRequest {
 export interface AmplitudeEvent {
   user_id: string;
   event_type: string;
-  event_properties: { [key: string]: any };
+  event_properties: Record<string, any>;
 }
 
 // struct2ts:types/generated/types.AmplitudeUploadRequestBody
@@ -4174,7 +4170,7 @@ export interface User {
   HasPhoneNumber: boolean;
   CanCreateProfile: boolean;
   // https://github.com/deso-protocol/backend/blob/983c803c2f3f441fb49e13c73cc27a26ecf52375/routes/global_state.go#L333
-  BlockedPubKeys: { [key: string]: {} };
+  BlockedPubKeys: Record<string, {}>;
   HasEmail: boolean;
   EmailVerified: boolean;
   JumioStartTime: number;
@@ -4229,7 +4225,7 @@ export interface UpdateProfileRequest {
   NewCreatorBasisPoints: number;
   NewStakeMultipleBasisPoints: number;
   IsHidden: boolean;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[] | null;
 }
@@ -4315,7 +4311,7 @@ export interface SubmitPostRequest {
   ParentStakeID: string;
   BodyObj: DeSoBodySchema;
   RepostedPostHashHex: string;
-  PostExtraData: { [key: string]: string };
+  PostExtraData: Record<string, string>;
   IsHidden: boolean;
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[] | null;
@@ -4533,13 +4529,11 @@ export interface AccessGroupMemberLimitMapItem {
 // struct2ts:types/generated/types.TransactionSpendingLimitResponse
 export interface TransactionSpendingLimitResponse {
   GlobalDESOLimit?: number;
-  TransactionCountLimitMap?: { [key: string]: number };
-  CreatorCoinOperationLimitMap?: { [key: string]: { [key: string]: number } };
-  DAOCoinOperationLimitMap?: { [key: string]: { [key: string]: number } };
-  NFTOperationLimitMap?: {
-    [key: string]: { [key: number]: { [key: string]: number } };
-  };
-  DAOCoinLimitOrderLimitMap?: { [key: string]: { [key: string]: number } };
+  TransactionCountLimitMap?: Partial<Record<TransactionType, number>>;
+  CreatorCoinOperationLimitMap?: Record<string, Record<string, number>>;
+  DAOCoinOperationLimitMap?: Record<string, Record<string, number>>;
+  NFTOperationLimitMap?: Record<string, Record<number, Record<string, number>>>;
+  DAOCoinLimitOrderLimitMap?: Record<string, Record<string, number>>;
   AssociationLimitMap?: AssociationLimitMapItem[];
   AccessGroupLimitMap?: AccessGroupLimitMapItem[];
   AccessGroupMemberLimitMap?: AccessGroupMemberLimitMapItem[];
@@ -4554,7 +4548,7 @@ export interface AuthorizeDerivedKeyRequest {
   AccessSignature: string;
   DeleteKey: boolean;
   DerivedKeySignature: boolean;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
   TransactionSpendingLimitHex: string;
   Memo: string;
   AppName: string;
@@ -4576,7 +4570,7 @@ export interface AuthorizeDerivedKeyResponse {
 // struct2ts:types/generated/types.AppendExtraDataRequest
 export interface AppendExtraDataRequest {
   TransactionHex: string;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.AppendExtraDataResponse
@@ -4633,7 +4627,7 @@ export interface GetUsersStatelessRequest {
 export interface GetUsersResponse {
   UserList: User[] | null;
   DefaultFeeRateNanosPerKB: number;
-  ParamUpdaters: { [key: string]: boolean };
+  ParamUpdaters: Record<string, boolean>;
 }
 
 // struct2ts:types/generated/types.GetUserMetadataRequest
@@ -4645,7 +4639,7 @@ export interface GetUserMetadataRequest {
 export interface GetUserMetadataResponse {
   HasPhoneNumber: boolean;
   CanCreateProfile: boolean;
-  BlockedPubKeys: { [key: string]: any };
+  BlockedPubKeys: Record<string, any>;
   HasEmail: boolean;
   EmailVerified: boolean;
   JumioFinishedTime: number;
@@ -4717,7 +4711,7 @@ export interface DiamondSenderSummaryResponse {
   ReceiverPublicKeyBase58Check: string;
   TotalDiamonds: number;
   HighestDiamondLevel: number;
-  DiamondLevelMap: { [key: number]: number };
+  DiamondLevelMap: Record<number, number>;
   ProfileEntryResponse: ProfileEntryResponse | null;
 }
 
@@ -4744,7 +4738,7 @@ export interface GetFollowsStatelessRequest {
 
 // struct2ts:types/generated/types.GetFollowsResponse
 export interface GetFollowsResponse {
-  PublicKeyToProfileEntry: { [key: string]: ProfileEntryResponse };
+  PublicKeyToProfileEntry: Record<string, ProfileEntryResponse>;
   NumFollowers: number;
 }
 
@@ -4765,7 +4759,7 @@ export interface UpdateUserGlobalMetadataRequest {
   UserPublicKeyBase58Check: string;
   JWT: string;
   Email: string;
-  MessageReadStateUpdatesByContact: { [key: string]: number };
+  MessageReadStateUpdatesByContact: Record<string, number>;
 }
 
 // struct2ts:types/generated/types.GetNotificationsCountRequest
@@ -4785,7 +4779,7 @@ export interface GetNotificationsRequest {
   PublicKeyBase58Check: string;
   FetchStartIndex: number;
   NumToFetch: number;
-  FilteredOutNotificationCategories: { [key: string]: boolean };
+  FilteredOutNotificationCategories: Record<string, boolean>;
 }
 
 // struct2ts:types/generated/types.TransactionMetadataResponse
@@ -4799,8 +4793,8 @@ export interface TransactionMetadataResponse {
 // struct2ts:types/generated/types.GetNotificationsResponse
 export interface GetNotificationsResponse {
   Notifications: TransactionMetadataResponse[] | null;
-  ProfilesByPublicKey: { [key: string]: ProfileEntryResponse };
-  PostsByHash: { [key: string]: PostEntryResponse };
+  ProfilesByPublicKey: Record<string, ProfileEntryResponse>;
+  PostsByHash: Record<string, PostEntryResponse>;
   LastSeenIndex: number;
 }
 
@@ -4823,7 +4817,7 @@ export interface BlockPublicKeyRequest {
 
 // struct2ts:types/generated/types.BlockPublicKeyResponse
 export interface BlockPublicKeyResponse {
-  BlockedPublicKeys: { [key: string]: string };
+  BlockedPublicKeys: Record<string, string>;
 }
 
 // struct2ts:types/generated/types.IsFollowingPublicKeyRequest
@@ -4861,14 +4855,14 @@ export interface UserDerivedKey {
   DerivedPublicKeyBase58Check: string;
   ExpirationBlock: number;
   IsValid: boolean;
-  ExtraData: { [key: string]: string };
+  ExtraData: Record<string, string>;
   TransactionSpendingLimit: TransactionSpendingLimitResponse | null;
   Memo: string;
 }
 
 // struct2ts:types/generated/types.GetUserDerivedKeysResponse
 export interface GetUserDerivedKeysResponse {
-  DerivedKeys: { [key: string]: UserDerivedKey };
+  DerivedKeys: Record<string, UserDerivedKey>;
 }
 
 // struct2ts:types/generated/types.GetTransactionSpendingLimitHexStringRequest
@@ -5111,7 +5105,7 @@ export interface CreateAccessGroupRequest {
   AccessGroupKeyName: string;
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[];
-  ExtraData: { [k: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 export interface CreateAccessGroupResponse {
@@ -5128,7 +5122,7 @@ export interface AccessGroupMember {
   AccessGroupMemberKeyName: string;
 
   EncryptedKey: string;
-  ExtraData?: { [k: string]: string };
+  ExtraData?: Record<string, string>;
 }
 
 export interface AddAccessGroupMembersRequest {
@@ -5140,7 +5134,7 @@ export interface AddAccessGroupMembersRequest {
 
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[];
-  ExtraData: { [k: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 export interface AddAccessGroupMembersResponse {
@@ -5155,14 +5149,14 @@ export interface AccessGroupMemberEntryResponse {
   AccessGroupMemberPublicKeyBase58Check: string;
   AccessGroupMemberKeyName: string;
   EncryptedKey: string;
-  ExtraData?: { [k: string]: string };
+  ExtraData?: Record<string, string>;
 }
 
 export interface AccessGroupEntryResponse {
   AccessGroupOwnerPublicKeyBase58Check: string;
   AccessGroupKeyName: string;
   AccessGroupPublicKeyBase58Check: string;
-  ExtraData?: { [k: string]: string };
+  ExtraData?: Record<string, string>;
   AccessGroupMemberEntryResponse: AccessGroupMemberEntryResponse | null;
 }
 
@@ -5213,13 +5207,15 @@ export interface GetPaginatedAccessGroupMembersRequest {
   MaxMembersToFetch: number;
 }
 
-export interface PublicKeyToProfileEntryResponseMap {
-  [k: string]: ProfileEntryResponse | null;
-}
+export type PublicKeyToProfileEntryResponseMap = Record<
+  string,
+  ProfileEntryResponse | null
+>;
 
-export interface PostHashHexToPostEntryResponseMap {
-  [k: string]: PostEntryResponse | null;
-}
+export type PostHashHexToPostEntryResponseMap = Record<
+  string,
+  PostEntryResponse | null
+>;
 
 export interface GetPaginatedAccessGroupMembersResponse {
   AccessGroupMembersBase58Check: string[];
@@ -5255,7 +5251,7 @@ export interface SendNewMessageRequest {
 
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[];
-  ExtraData: { [k: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 export interface SendNewMessageResponse {
@@ -5290,7 +5286,7 @@ export interface MessageInfo {
   EncryptedText: string;
   TimestampNanos: number;
   TimestampNanosString: string;
-  ExtraData: { [k: string]: string };
+  ExtraData: Record<string, string>;
 }
 
 export interface GetPaginatedMessagesForDmThreadRequest {
@@ -5380,7 +5376,7 @@ export interface CreateAssociationRequest {
   AppPublicKeyBase58Check: string;
   AssociationType: string;
   AssociationValue: string;
-  ExtraData: { [k: string]: string };
+  ExtraData: Record<string, string>;
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[];
 }
@@ -5399,7 +5395,7 @@ export interface AssociationResponse {
   AppPublicKeyBase58Check: string;
   AssociationType: string;
   AssociationValue: string;
-  ExtraData: { [k: string]: string };
+  ExtraData: Record<string, string>;
   BlockHeight: number;
   TransactorProfile: ProfileEntryResponse | null;
   AppProfile: ProfileEntryResponse | null;
@@ -5431,7 +5427,7 @@ export interface PostAssociationsResponse {
 export interface DeleteAssociationRequest {
   TransactorPublicKeyBase58Check: string;
   AssociationID: string;
-  ExtraData: { [k: string]: string };
+  ExtraData: Record<string, string>;
   MinFeeRateNanosPerKB: number;
   TransactionFees: TransactionFee[];
 }
@@ -5451,7 +5447,7 @@ export interface AssociationsCountResponse {
 }
 
 export interface AssociationCountsResponse {
-  Counts: { [k: string]: number };
+  Counts: Record<string, number>;
   Total: number;
 }
 
@@ -5483,7 +5479,7 @@ export interface GetVideoStatusResponse {
   createdAt: number;
   videoSpec: {
     format: string;
-    tracks: {
+    tracks: Array<{
       fps: number;
       type: string;
       codec: string;
@@ -5492,7 +5488,7 @@ export interface GetVideoStatusResponse {
       bitrate: number;
       duration: number;
       pixelFormat: string;
-    }[];
+    }>;
     duration: number;
   };
   playbackID: string;

--- a/src/identity/identity.spec.ts
+++ b/src/identity/identity.spec.ts
@@ -1,4 +1,4 @@
-import { getPublicKey, utils as ecUtils } from '@noble/secp256k1';
+import { utils as ecUtils, getPublicKey } from '@noble/secp256k1';
 import { verify } from 'jsonwebtoken';
 import KeyEncoder from 'key-encoder';
 import { ChatType, NewMessageEntryResponse } from '../backend-types';

--- a/src/identity/permissions-utils.ts
+++ b/src/identity/permissions-utils.ts
@@ -3,7 +3,6 @@ import {
   TransactionType,
 } from '../backend-types';
 import { identity } from '../identity';
-import { globalConfigOptions } from '../internal';
 import { TransactionSpendingLimitResponseOptions } from './types';
 export function compareTransactionSpendingLimits(
   expectedPermissions: any,
@@ -112,11 +111,11 @@ export function guardTxPermission(
   options?: {
     fallbackTxLimitCount?: number;
     txAmountDESONanos?: number;
-    txFeeRateNanosPerKB?: number;
   }
 ) {
   if (
     !identity.hasPermissions({
+      GlobalDESOLimit: options?.txAmountDESONanos ?? 0,
       TransactionCountLimitMap: {
         [txType]: 1,
       },
@@ -125,9 +124,7 @@ export function guardTxPermission(
     return identity.requestPermissions({
       GlobalDESOLimit: Math.max(
         identity.transactionSpendingLimitOptions.GlobalDESOLimit ?? 0,
-        (options?.txAmountDESONanos ?? 0) +
-          (options?.txFeeRateNanosPerKB ??
-            globalConfigOptions.MinFeeRateNanosPerKB)
+        options?.txAmountDESONanos ?? 0
       ),
       // TODO: handle dao, nft, association limit maps, etc.
       TransactionCountLimitMap: {

--- a/src/identity/permissions-utils.ts
+++ b/src/identity/permissions-utils.ts
@@ -1,4 +1,9 @@
-import { TransactionSpendingLimitResponse } from '../backend-types';
+import {
+  TransactionSpendingLimitResponse,
+  TransactionType,
+} from '../backend-types';
+import { identity } from '../identity';
+import { globalConfigOptions } from '../internal';
 import { TransactionSpendingLimitResponseOptions } from './types';
 export function compareTransactionSpendingLimits(
   expectedPermissions: any,
@@ -85,20 +90,57 @@ export function buildTransactionSpendingLimitResponse(
     });
   }
 
-  if (result.TransactionCountLimitMap) {
-    if (
-      typeof result.TransactionCountLimitMap['AUTHORIZE_DERIVED_KEY'] ===
-      'undefined'
-    ) {
-      result.TransactionCountLimitMap = {
-        ...result.TransactionCountLimitMap,
-        AUTHORIZE_DERIVED_KEY: 1,
-      };
-    } else if (result.TransactionCountLimitMap['AUTHORIZE_DERIVED_KEY'] < 0) {
-      delete result.TransactionCountLimitMap['AUTHORIZE_DERIVED_KEY'];
-    }
+  result.TransactionCountLimitMap = result.TransactionCountLimitMap ?? {};
+
+  if (
+    typeof result.TransactionCountLimitMap['AUTHORIZE_DERIVED_KEY'] ===
+    'undefined'
+  ) {
+    result.TransactionCountLimitMap = {
+      ...result.TransactionCountLimitMap,
+      AUTHORIZE_DERIVED_KEY: 1,
+    };
+  } else if (result.TransactionCountLimitMap['AUTHORIZE_DERIVED_KEY'] < 0) {
+    delete result.TransactionCountLimitMap['AUTHORIZE_DERIVED_KEY'];
   }
+
   return result;
+}
+
+export function guardTxPermission(
+  txType: TransactionType,
+  options?: {
+    fallbackTxLimitCount?: number;
+    txAmountDESONanos?: number;
+    txFeeRateNanosPerKB?: number;
+  }
+) {
+  if (
+    !identity.hasPermissions({
+      TransactionCountLimitMap: {
+        [txType]: 1,
+      },
+    })
+  ) {
+    return identity.requestPermissions({
+      GlobalDESOLimit: Math.max(
+        identity.transactionSpendingLimitOptions.GlobalDESOLimit ?? 0,
+        (options?.txAmountDESONanos ?? 0) +
+          (options?.txFeeRateNanosPerKB ??
+            globalConfigOptions.MinFeeRateNanosPerKB)
+      ),
+      // TODO: handle dao, nft, association limit maps, etc.
+      TransactionCountLimitMap: {
+        [txType]:
+          identity.transactionSpendingLimitOptions.TransactionCountLimitMap
+            ?.SUBMIT_POST ??
+          options?.fallbackTxLimitCount ??
+          1,
+      },
+    });
+  }
+
+  return Promise.resolve();
 }
 
 function walkObj(

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -3,6 +3,7 @@ import {
   AccessGroupMemberLimitMapItem,
   AssociationLimitMapItem,
   TransactionSpendingLimitResponse,
+  TransactionType,
 } from '../backend-types';
 export type Network = 'mainnet' | 'testnet';
 
@@ -35,7 +36,9 @@ export interface IdentityDerivePayload {
 
 export interface TransactionSpendingLimitResponseOptions {
   GlobalDESOLimit?: number;
-  TransactionCountLimitMap?: { [key: string]: number | 'UNLIMITED' };
+  TransactionCountLimitMap?: Partial<
+    Record<TransactionType, number | 'UNLIMITED'>
+  >;
   CreatorCoinOperationLimitMap?: {
     [key: string]: { [key: string]: number | 'UNLIMITED' };
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,8 @@
-import { SubmitTransactionResponse, TransactionFee } from './backend-types';
+import {
+  RequestOptions,
+  SubmitTransactionResponse,
+  TransactionFee,
+} from './backend-types';
 export interface OptionalFeesAndExtraData {
   MinFeeRateNanosPerKB?: number;
   TransactionFees?: TransactionFee[] | null;
@@ -16,3 +20,8 @@ export interface ConstructedAndSubmittedTx<T> {
   // This will be null if the broadcast option is set to false.
   submittedTransactionResponse: SubmitTransactionResponse | null;
 }
+
+export type TxRequestOptions = RequestOptions & {
+  txLimitCount?: number;
+  checkPermissions?: boolean;
+};


### PR DESCRIPTION
If a derived key is invalid it will cause the transaction submit to fail. This can currently be handled on the application side by eagerly checking if the key has all he required permissions and enough deso via the `hasPermissions` method from the desojs identity instance. If this method returns false, we can use `requestPermissions` to open the derived key approval window. 

This PR makes this the default behavior and handles it internally. Apps can disable this if they want to.

The `txLimitCount` option is available on all transaction construction wrappers and defaults to the value 1.

We also consider the global deso limit not being enough to pay for the tx + fees. If the available deso is not enough to cover the tx, we request approval for `Math.max(txAmount + fees, OriginalGlobalDESOLimit)`