### PR TITLE
react native support

### DIFF
--- a/src/identity/identity.spec.ts
+++ b/src/identity/identity.spec.ts
@@ -211,7 +211,7 @@ describe('identity', () => {
         ),
       ]);
 
-      const { currentUser } = await identity.snapshot();
+      const { currentUser } = identity.snapshotSync();
       expect(currentUser?.publicKey).toEqual(
         'BC1YLiot3hqKeKhK82soKAeK3BFdTnMjpd2w4HPfesaFzYHUpUzJ2ay'
       );

--- a/src/identity/identity.spec.ts
+++ b/src/identity/identity.spec.ts
@@ -103,6 +103,9 @@ describe('identity', () => {
         .mockName('api.post'),
     });
     identity = new Identity(windowFake, apiFake);
+    identity.configure({
+      storageProvider: windowFake.localStorage,
+    });
   });
 
   describe('.login()', () => {
@@ -143,6 +146,7 @@ describe('identity', () => {
       const testAppName = 'My Cool App';
       identity.configure({
         appName: testAppName,
+        storageProvider: windowFake.localStorage,
       });
 
       let loginKeyPair = { publicKey: '', seedHex: '' };
@@ -207,12 +211,13 @@ describe('identity', () => {
         ),
       ]);
 
-      expect(identity.snapshot().currentUser?.publicKey).toEqual(
+      const { currentUser } = await identity.snapshot();
+      expect(currentUser?.publicKey).toEqual(
         'BC1YLiot3hqKeKhK82soKAeK3BFdTnMjpd2w4HPfesaFzYHUpUzJ2ay'
       );
       expect(loginKeyPair.seedHex.length > 0).toBe(true);
       expect(loginKeyPair.publicKey.length > 0).toBe(true);
-      expect(identity.snapshot().currentUser).toEqual({
+      expect(currentUser).toEqual({
         publicKey: derivePayload.publicKeyBase58Check,
         primaryDerivedKey: {
           ...derivePayload,
@@ -602,7 +607,8 @@ describe('identity', () => {
           },
         })
       );
-      const hasPermissions = identity.hasPermissions({
+
+      const hasPermissions = identity.hasPermissionsSync({
         TransactionCountLimitMap: {
           BASIC_TRANSFER: 1,
           SUBMIT_POST: 1,
@@ -647,7 +653,7 @@ describe('identity', () => {
           },
         })
       );
-      const hasPermissions = identity.hasPermissions({
+      const hasPermissions = identity.hasPermissionsSync({
         TransactionCountLimitMap: {
           BASIC_TRANSFER: 1,
           SUBMIT_POST: 1,
@@ -692,7 +698,7 @@ describe('identity', () => {
           },
         })
       );
-      const hasPermissions = identity.hasPermissions({
+      const hasPermissions = identity.hasPermissionsSync({
         TransactionCountLimitMap: {
           SUBMIT_POST: 3, // more than the user can do
         },
@@ -719,7 +725,7 @@ describe('identity', () => {
           },
         })
       );
-      const hasPermissions = identity.hasPermissions({
+      const hasPermissions = identity.hasPermissionsSync({
         TransactionCountLimitMap: {
           SUBMIT_POST: 3, // doesn't matter what we check, it should be allowed
         },
@@ -756,7 +762,7 @@ describe('identity', () => {
           },
         })
       );
-      const hasPermissions = identity.hasPermissions({
+      const hasPermissions = identity.hasPermissionsSync({
         TransactionCountLimitMap: {
           BASIC_TRANSFER: 'UNLIMITED',
         },
@@ -792,7 +798,7 @@ describe('identity', () => {
           },
         })
       );
-      const hasPermissions = identity.hasPermissions({
+      const hasPermissions = identity.hasPermissionsSync({
         TransactionCountLimitMap: {
           // basic transfer is not in the user's actual permissions
           BASIC_TRANSFER: 1,

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -371,6 +371,7 @@ export class Identity {
    * Same as snapshot except it runs synchronously. This exists primarily for
    * backwards compatibility should only be used in a browser context where
    * localStorage is available.
+   * @deprecated use `snapshot` instead.
    */
   snapshotSync(): {
     currentUser: StoredUser | null;

--- a/src/identity/identity.ts
+++ b/src/identity/identity.ts
@@ -936,6 +936,12 @@ export class Identity {
       throw new Error('You must pass at least one permission to check');
     }
 
+    if (!this.#window.localStorage) {
+      throw new Error(
+        'You must be in a browser context to use hasPermissionsSync. Did you mean to use hasPermissionsAsync?'
+      );
+    }
+
     // NOTE: We're making an assumption here that the storage provider is
     // browser localStorage, which has a synchronous API.
     const usersJSON = this.#window.localStorage.getItem(

--- a/src/identity/permissions-utils.ts
+++ b/src/identity/permissions-utils.ts
@@ -188,7 +188,7 @@ export function buildTransactionSpendingLimitResponse(
 export function guardTxPermission(
   spendingLimitOptions: TransactionSpendingLimitResponseOptions
 ) {
-  if (!identity.hasPermissions(spendingLimitOptions)) {
+  if (!identity.hasPermissionsSync(spendingLimitOptions)) {
     return identity.requestPermissions({
       ...spendingLimitOptions,
       GlobalDESOLimit:

--- a/src/identity/permissions-utils.ts
+++ b/src/identity/permissions-utils.ts
@@ -185,10 +185,25 @@ export function buildTransactionSpendingLimitResponse(
   return result;
 }
 
-export function guardTxPermission(
+export async function guardTxPermission(
   spendingLimitOptions: TransactionSpendingLimitResponseOptions
 ) {
-  if (!identity.hasPermissionsSync(spendingLimitOptions)) {
+  let hasPermissions = false;
+
+  try {
+    hasPermissions = identity.hasPermissionsSync(spendingLimitOptions);
+  } catch (e: any) {
+    if (
+      e?.message?.includes(
+        'You must be in a browser context to use hasPermissionsSync'
+      )
+    ) {
+      // Try falling back to hasPermissionsAsync
+      hasPermissions = await identity.hasPermissionsAsync(spendingLimitOptions);
+    }
+  }
+
+  if (!hasPermissions) {
     return identity.requestPermissions({
       ...spendingLimitOptions,
       GlobalDESOLimit:

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -98,18 +98,20 @@ export interface IdentityConfiguration {
    */
   appName?: string;
 
-  // Since our keys are generated using the secp256k1 curve, the correct
-  // JWT algorithm header *should* be ES256K.
-  // See: https://www.rfc-editor.org/rfc/rfc8812.html#name-jose-algorithms-registratio
-  //
-  // HOWEVER, the backend jwt lib used by deso foundation -
-  // https://github.com/golang-jwt/jwt - (as well as many other jwt libraries)
-  // do not support ES256K. So instead, we default to the more widely supported ES256 algo,
-  // which can still work for verifying our signatures. But if a consumer of this lib is using a
-  // jwt lib that supports ES256K they can specify that here.
-  // See this github issue
-  // for more context: https://github.com/auth0/node-jsonwebtoken/issues/862
-  // If ES256K is ever supported by the backend jwt lib, we should change this.
+  /**
+   * Since our keys are generated using the secp256k1 curve, the correct
+   * JWT algorithm header *should* be ES256K.
+   * See: https://www.rfc-editor.org/rfc/rfc8812.html#name-jose-algorithms-registratio
+   *
+   * HOWEVER, the backend jwt lib used by deso foundation -
+   * https://github.com/golang-jwt/jwt - (as well as many other jwt libraries)
+   * do not support ES256K. So instead, we default to the more widely supported ES256 algo,
+   * which can still work for verifying our signatures. But if a consumer of this lib is using a
+   * jwt lib that supports ES256K they can specify that here.
+   * See this github issue
+   * for more context: https://github.com/auth0/node-jsonwebtoken/issues/862
+   * If ES256K is ever supported by the backend jwt lib, we should change this.
+   */
   jwtAlgorithm?: jwtAlgorithm;
 
   /**

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -125,6 +125,12 @@ export interface IdentityConfiguration {
    * opened. This can be used to customize how the identity url is opened. For
    * example, if you are using react native, you might want to use the Linking
    * API to open the url in a system browser window.
+   * @example
+   * ```ts
+   * identityPresenter: (url) => {
+   *   WebBrowser.openBrowserAsync(url);
+   * },
+   * ```
    */
   identityPresenter?: (url: string) => void;
 

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -111,6 +111,40 @@ export interface IdentityConfiguration {
   // for more context: https://github.com/auth0/node-jsonwebtoken/issues/862
   // If ES256K is ever supported by the backend jwt lib, we should change this.
   jwtAlgorithm?: jwtAlgorithm;
+
+  /**
+   *
+   */
+  storageProvider?: Storage | AsyncStorage;
+
+  /**
+   * An optional function that is provided the identity url that needs to be
+   * opened. This can be used to customize how the identity url is opened. For
+   * example, if you are using react native, you might want to use the Linking
+   * API to open the url in a system browser window.
+   */
+  identityPresenter?: (url: string) => void;
+
+  /**
+   * A function that returns a promise that resolves to a
+   * redirect url. This would be used in the context of react native application
+   * that needs to propagate the redirect url to the identity library.
+   * NOTE: This is required if you are using a custom identityPresenter.
+   * @example
+   * ```ts
+   *   identityRedirectResolver: () => {
+   *     return new Promise((resolve) => {
+   *       // This is an example of how you might use the Linking API in react native,
+   *       // assuming you've opened a browser window to the identity domain.
+   *       Linking.addEventListener('url', ({ url }) => {
+   *         WebBrowser.dismissBrowser();
+   *         resolve(url);
+   *       });
+   *     });
+   *   },
+   * ```
+   */
+  identityRedirectResolver?: () => Promise<string>;
 }
 
 export interface APIProvider {
@@ -309,4 +343,11 @@ export enum NOTIFICATION_EVENTS {
    * This event is fired when the consuming app switches the active user.
    */
   CHANGE_ACTIVE_USER = 'CHANGE_ACTIVE_USER',
+}
+
+export interface AsyncStorage {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+  clear: () => Promise<void>;
 }

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -113,7 +113,8 @@ export interface IdentityConfiguration {
   jwtAlgorithm?: jwtAlgorithm;
 
   /**
-   *
+   * An optional storage provider. If not provided, we will assume localStorage
+   * is available.
    */
   storageProvider?: Storage | AsyncStorage;
 

--- a/src/jwt-requests.ts
+++ b/src/jwt-requests.ts
@@ -64,12 +64,12 @@ import {
   WyreWalletOrderQuotationPayload,
   WyreWalletOrderReservationPayload,
 } from './backend-types';
-import { api, cleanURL, media, PartialWithRequiredFields } from './data';
+import { PartialWithRequiredFields, api, cleanURL, media } from './data';
 import {
-  encodeUTF8ToBytes,
-  identity,
   TransactionExtraDataKV,
   TransactionMetadataUpdateGlobalParams,
+  encodeUTF8ToBytes,
+  identity,
   uvarint64ToBuf,
 } from './identity';
 import { constructBalanceModelTx, handleSignAndSubmit } from './internal';
@@ -83,7 +83,7 @@ const jwtPost = async (
   let AdminPublicKey = '';
 
   if (isAdminRequest) {
-    const { currentUser } = identity.snapshot();
+    const { currentUser } = await identity.snapshot();
 
     if (!currentUser) {
       throw new Error('Cannot issue an admin request without a logged in user');

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,4 +1,4 @@
-import { APIProvider } from "./identity";
+import { APIProvider } from './identity';
 
 class LocalStorageFake implements Storage {
   db: Record<string, string> = {};
@@ -18,9 +18,11 @@ class LocalStorageFake implements Storage {
   getItem(key: string) {
     return this.db[key] ?? null;
   }
+
   setItem(key: string, value: string) {
     this.db[key] = value;
   }
+
   removeItem(key: string) {
     delete this.db[key];
   }
@@ -29,7 +31,7 @@ class LocalStorageFake implements Storage {
 export function getWindowFake(overrides: Partial<Window> = {}): Window {
   overrides.location = {
     ...window.location,
-    hostname: "localhost.test",
+    hostname: 'localhost.test',
     ...(overrides.location ?? {}),
   };
 


### PR DESCRIPTION
To support react native we've introduced a few new optional configuration options for customizing how the identity url is opened and how the payload is received. Namely the following options:

```ts
  /**
   * An optional storage provider. If not provided, we will assume localStorage
   * is available.
   */
  storageProvider?: Storage | AsyncStorage;

  /**
   * An optional function that is provided the identity url that needs to be
   * opened. This can be used to customize how the identity url is opened. For
   * example, if you are using react native, you might want to use the Linking
   * API to open the url in a system browser window.
   */
  identityPresenter?: (url: string) => void;

  /**
   * A function that returns a promise that resolves to a
   * redirect url. This would be used in the context of react native application
   * that needs to propagate the redirect url to the identity library.
   * NOTE: This is required if you are using a custom identityPresenter.
   * @example
   * ```ts
   *   identityRedirectResolver: () => {
   *     return new Promise((resolve) => {
   *       // This is an example of how you might use the Linking API in react native,
   *       // assuming you've opened a browser window to the identity domain.
   *       Linking.addEventListener('url', ({ url }) => {
   *         WebBrowser.dismissBrowser();
   *         resolve(url);
   *       });
   *     });
   *   },
   * ```
   */
  identityRedirectResolver?: () => Promise<string>;
  ```
  
NOTE: This is a breaking change since we needed to convert some public apis to be async that were previously synchronous to support AsyncStorage in react native. In the case of `hasPermissions` which *must* be synchronous in a browser we've introduced 2 variants: `hasPermissionsSync` and `hasPermissionsAsync`